### PR TITLE
enable batched and nonwaiting appends, improving performance 3000x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,6 @@ processing that is easily scalable. Streaming primarily consists of
 * a producer, which is some function inserting data into the stream
 * a consumer, which is some function retrieving data from the stream
 * transform and windowing functions to process the data in small batches and in parallel
-* a Flask
 
 minibatch is an integral part of `omega|ml <https://github.com/omegaml/omegaml>`_, however also works independently. omega|ml is the Python DataOps and MLOps
 platform for humans.
@@ -36,6 +35,7 @@ A few hightlights
 * producer and consumer stream code runs anywhere
 * no dependencies other than mongoengine, pymongo
 * extensible sources and sinks (already available: Kafka, MQTT, MongoDB collections, omega|ml datasets)
+* a fully functional streaming web app can be built in less than 15 lines of code (using Flask)
 
 Why is it called *mini*batch? Because it focuses on getting things done by using existing
 technology, and making it easy to use this techonlogy. It may be minimalistic in approach, but maximises results.
@@ -57,8 +57,8 @@ Quick start
 
    .. code::
 
-        from minibatch import stream
-        stream = Stream.get_or_create('test')
+        import minibatch as mb
+        stream = mb.stream('test')
         for i in range(100):
             stream.append({'date': datetime.datetime.now().isoformat()})
             sleep(.5)

--- a/minibatch/window.py
+++ b/minibatch/window.py
@@ -303,7 +303,7 @@ class RelaxedTimeWindow(WindowEmitter):
 
     def query(self, *args):
         last_read, max_read = args
-        fltkwargs = dict(stream=self.stream_name, created__gt=last_read,
+        fltkwargs = dict(stream=self.stream_name,
                          created__lte=max_read, processed=False)
         return Buffer.objects.no_cache().filter(**fltkwargs)
 


### PR DESCRIPTION
prior to this we have seen stream.append maxing out at ~20 records/seconds (single node). We can now get up to 60K messages/seconds, a 3000x improvement (also single node). This is as of yet a straight forward benchmark measuring the time it takes two worker processes to insert 500'000 K messages in total, with batchsize=1000. 

Major Changes:
* inserts by default use a write_concern=0 (no ack writes). use mb.stream(...., fast_insert=False) to use the default write concern
* inserts can be batched (optionally) by using mb.stream(...., batchsize=N), which means appends use collection.insert_many(). In this case be sure to use stream.flush() on the last insert, or on some interval (there is currently no autoflush other than when the batching buffer is full) 
* enabled passing of ssl=True kwargs on stream creation and db connection registration