### PR TITLE
simplify, fix issues

### DIFF
--- a/.tarignore
+++ b/.tarignore
@@ -1,0 +1,4 @@
+.tox
+.venv
+.git
+

--- a/minibatch/__init__.py
+++ b/minibatch/__init__.py
@@ -77,12 +77,10 @@ def streaming(name, fn=None, interval=None, size=None, emitter=None,
 
 
 def stream(name, fn=None, url=None, ssl=False, **kwargs):
-    kwargs.update(url=url, ssl=ssl)
-    stream = Stream.get_or_create(name, **kwargs)
-    fn = fn or name if callable(name) else fn
     if callable(fn):
         return streaming(name, url=url, ssl=ssl, **kwargs)(fn)
-    return stream
+    kwargs.update(url=url, ssl=ssl)
+    return Stream.get_or_create(name, **kwargs)
 
 
 class IntegrityError(Exception):

--- a/minibatch/tests/test_omegaml.py
+++ b/minibatch/tests/test_omegaml.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase
 
 try:
@@ -47,6 +46,7 @@ try:
 
         def test_sink(self):
             om = self.om
+            db = self.db # noqa
             url = str(self.url)
 
             source = DatasetSource(om, 'stream-test')
@@ -68,6 +68,8 @@ try:
             em.should_stop = lambda *args, **kwargs: om.datasets.collection('stream-sink').count_documents({}) > 0
             em.run(blocking=True)
             s.stop()
+
+            docs = list(db.processed.find())
             docs = list(om.datasets.collection('stream-sink').find())
             self.assertEqual(len(docs), 1)
 


### PR DESCRIPTION
- add Stream.get_or_create(..., max_age=N) option to specify maximum age in seconds; if specified all buffered messages older than this will be discarded