### PR TITLE
Enable stream chords

### DIFF
--- a/minibatch/__init__.py
+++ b/minibatch/__init__.py
@@ -13,7 +13,7 @@ mongo_pid = None
 
 
 def streaming(name, interval=None, size=None, emitter=None,
-              relaxed=True, keep=False, url=None, sink=None,
+              relaxed=True, keep=False, url=None, sink=None, chord=None,
               queue=None, source=None, blocking=True, **kwargs):
     """
     make and call a streaming function
@@ -61,7 +61,7 @@ def streaming(name, interval=None, size=None, emitter=None,
     def make(fn):
         return make_emitter(name, fn, interval=interval, size=size,
                             emitter=emitter, relaxed=relaxed, keep=keep,
-                            url=url, sink=sink, queue=queue, source=source,
+                            url=url, sink=sink, chord=chord, queue=queue, source=source,
                             **kwargs)
 
     def inner(fn):
@@ -85,7 +85,7 @@ class IntegrityError(Exception):
 
 def make_emitter(name, emitfn, interval=None, size=None, relaxed=False,
                  url=None, sink=None, emitter=None, keep=False, queue=None,
-                 source=None, cnx_kwargs=None, **kwargs):
+                 source=None, chord=None, cnx_kwargs=None, **kwargs):
     from minibatch.window import RelaxedTimeWindow, FixedTimeWindow, CountWindow
 
     if interval is None and size is None:
@@ -98,7 +98,7 @@ def make_emitter(name, emitfn, interval=None, size=None, relaxed=False,
     stream = Stream.get_or_create(name, interval=interval or size, **cnx_kwargs)
     # create the emitter
     emitfn._count = 0
-    kwargs.update(stream=stream, emitfn=emitfn, forwardfn=forwardfn, queue=queue)
+    kwargs.update(stream=stream, emitfn=emitfn, forwardfn=forwardfn, queue=queue, chord=chord)
     if interval and emitter is None:
         if relaxed:
             em = RelaxedTimeWindow(name, interval=interval, **kwargs)

--- a/minibatch/__init__.py
+++ b/minibatch/__init__.py
@@ -5,7 +5,7 @@ from pymongo.errors import AutoReconnect
 from time import sleep
 
 from minibatch._version import version  # noqa
-from minibatch.models import Stream, Buffer, Window  # noqa
+from minibatch.models import Stream, Buffer, Window, Participant  # noqa
 
 logger = logging.getLogger(__name__)
 mongo_pid = None
@@ -66,7 +66,6 @@ def streaming(name, interval=None, size=None, emitter=None,
     def inner(fn):
         if not hasattr(inner, '_em'):
             inner._em = make(fn)
-
         inner._em.run(blocking=blocking)
 
     inner.apply = lambda fn: inner(fn)
@@ -91,13 +90,14 @@ def make_emitter(name, emitfn, interval=None, size=None, relaxed=False,
 
     if interval is None and size is None:
         size = 1
-
+    # support autoforwarding to a sink
     forwardfn = sink.put if sink else None
-
-    emitfn._count = 0
+    # create the stream
     cnx_kwargs = cnx_kwargs or {}
     cnx_kwargs.update(url=url) if url else None
     stream = Stream.get_or_create(name, interval=interval or size, **cnx_kwargs)
+    # create the emitter
+    emitfn._count = 0
     kwargs.update(stream=stream, emitfn=emitfn, forwardfn=forwardfn, queue=queue)
     if interval and emitter is None:
         if relaxed:
@@ -166,7 +166,7 @@ def connectdb(url=None, dbname=None, alias=None, authSource='admin',
     from mongoengine import connect
     from mongoengine.connection import get_db
 
-    url = url or os.environ.get('MINIBATCH_MONGO_URL') or os.environ.get('MONGO_URL')
+    url = url or os.environ.get('MINIBATCH_MONGO_URL') or os.environ.get('MONGO_URL') or 'mongodb://localhost:27017'
     url = authenticated_url(url, authSource=authSource) if authSource else url
     alias = alias or 'minibatch'
     reset_mongoengine()

--- a/minibatch/__init__.py
+++ b/minibatch/__init__.py
@@ -6,6 +6,7 @@ from time import sleep
 
 from minibatch._version import version  # noqa
 from minibatch.models import Stream, Buffer, Window, Participant  # noqa
+from minibatch.util import ProcessLocal
 
 logger = logging.getLogger(__name__)
 mongo_pid = None
@@ -69,7 +70,6 @@ def streaming(name, interval=None, size=None, emitter=None,
         inner._em.run(blocking=blocking)
 
     inner.apply = lambda fn: inner(fn)
-    inner.make = lambda fn: make(fn)
     return inner
 
 
@@ -108,10 +108,10 @@ def make_emitter(name, emitfn, interval=None, size=None, relaxed=False,
         em = CountWindow(name, interval=size, **kwargs)
     elif emitter is not None:
         em = emitter(name, emitfn=emitfn,
-                     interval=interval or size,
+                     size=size, interval=interval,
                      **kwargs)
     else:
-        raise ValueError("need either interval=, size= or emitter=")
+        raise ValueError("Cannot decide on emitter strategy, as need either interval=, size= or emitter= was provided.")
     em.persist(keep)
     if source:
         # starts a background thread that inserts source messages into the Buffer
@@ -129,6 +129,7 @@ def reset_mongoengine():
     # see https://stackoverflow.com/a/49404748/890242
     #     https://github.com/MongoEngine/mongoengine/issues/1599#issuecomment-374901186
     from mongoengine import connection
+    from minibatch import models
     # There is a fix in mongoengine 18.0 that is supposed to introduce the same
     # behavior using disconnection_all(), however in some cases this is the
     # actual source of the warning due to calling connection.close()
@@ -136,18 +137,22 @@ def reset_mongoengine():
     # -- the implemented solution simply ensures MongoClients get recreated
     #    whenever needed
 
-    def clean(d):
-        if 'minibatch' in d:
-            del d['minibatch']
-        if 'default' in d:
-            del d['default']
+    def ensure_process_local_connection(k):
+        if not isinstance(getattr(connection, k), ProcessLocal):
+            setattr(connection, k, ProcessLocal())
 
-    clean(connection._connection_settings)
-    clean(connection._connections)
-    clean(connection._dbs)
-    Window._collection = None
-    Buffer._collection = None
-    Stream._collection = None
+    def reset_model(k):
+        m = getattr(models, k)
+        m._collection = None
+
+    for k in ['_connection_settings', '_connections', '_dbs']:
+        ensure_process_local_connection(k)
+
+    if 'minibatch' not in getattr(connection, '_connections'):
+        for k in ['Stream', 'Buffer', 'Window', 'Participant']:
+            reset_model(k)
+        return True
+    return False
 
 
 def authenticated_url(mongo_url, authSource='admin'):
@@ -169,7 +174,6 @@ def connectdb(url=None, dbname=None, alias=None, authSource='admin',
     url = url or os.environ.get('MINIBATCH_MONGO_URL') or os.environ.get('MONGO_URL') or 'mongodb://localhost:27017'
     url = authenticated_url(url, authSource=authSource) if authSource else url
     alias = alias or 'minibatch'
-    reset_mongoengine()
     if False and fast_insert:
         # set writeConcern options
         # https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html?highlight=mongoclient
@@ -178,7 +182,8 @@ def connectdb(url=None, dbname=None, alias=None, authSource='admin',
         kwargs['w'] = 0
         kwargs['journal'] = False
     kwargs.setdefault('uuidRepresentation', 'standard')
-    connect(alias=alias, db=dbname, host=url, connect=False, **kwargs)
+    if reset_mongoengine():
+        connect(alias=alias, db=dbname, host=url, connect=False, **kwargs)
     waitForConnection(get_connection(alias))
     return get_db(alias=alias)
 
@@ -198,3 +203,4 @@ def waitForConnection(client):
             break
     if _exc is not None:
         raise _exc
+

--- a/minibatch/__main__.py
+++ b/minibatch/__main__.py
@@ -1,0 +1,27 @@
+import logging
+from time import sleep
+
+from minibatch import connectdb
+from minibatch.models import ThreadAlive, Monitor
+
+alive = ThreadAlive()
+#logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(message)s', datefmt='%H:%M:%S', )
+
+
+def monitor():
+    monitor = Monitor()
+    while alive:
+        print("*** Participants ***")
+        for participant in monitor.participants():
+            print(repr(participant))
+        sleep(5)
+
+
+def main():
+    print('minibatch!')
+    connectdb()
+    monitor()
+
+
+if __name__ == '__main__':
+    main()

--- a/minibatch/emitter/base.py
+++ b/minibatch/emitter/base.py
@@ -5,7 +5,7 @@ import logging
 
 from minibatch import Stream, logger
 from minibatch.marshaller import SerializableFunction, MinibatchFuture
-from minibatch.models import Buffer
+from minibatch.models import Buffer, Participant
 
 
 class Emitter(object):
@@ -73,6 +73,7 @@ class Emitter(object):
         self._delete_on_commit = True
         self._forwardfn = forwardfn
         self._stop = False
+        self._participant = None
 
     def query(self, *args):
         now, last_read = args
@@ -151,6 +152,7 @@ class Emitter(object):
         self._stop = True
 
     def run(self):
+        self._participant = Participant.for_stream(self.stream, 'consumer')
         while not self._stop:
             logger.debug("testing window ready")
             ready, query_args = self.ready()
@@ -190,3 +192,5 @@ class Emitter(object):
             self.sleep()
             logger.debug("awoke")
         self.executor.shutdown(wait=True)
+        self._participant.stop()
+        self._participant = None

--- a/minibatch/models.py
+++ b/minibatch/models.py
@@ -1,10 +1,20 @@
+from contextlib import contextmanager
+
+import random
+
+import os
+
+import threading
 from logging import warning
+from time import sleep
 
 import datetime
+import socket
 from mongoengine import Document
 from mongoengine.errors import NotUniqueError
 from mongoengine.fields import (StringField, IntField, DateTimeField,
                                 ListField, DictField, BooleanField)
+from random import randint
 from threading import Thread
 from uuid import uuid4
 
@@ -14,6 +24,20 @@ STATUS_CLOSED = 'closed'
 STATUS_PROCESSED = 'processed'
 STATUS_FAILED = 'failed'
 STATUS_CHOICES = (STATUS_OPEN, STATUS_CLOSED, STATUS_FAILED)
+
+
+class ThreadAlive(threading.Event):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.thread = None
+
+    def __bool__(self):
+        return not self.is_set()
+
+    def stop(self):
+        self.set()
+        self.thread.join(1) if self.thread else None
+        self.thread = None
 
 
 class Batcher:
@@ -111,6 +135,7 @@ class Window(ImmediateWriter, Document):
     to the WindowEmitter strategy.
     """
     stream = StringField(required=True)
+    chord = StringField(required=True, default='default')
     created = DateTimeField(default=datetime.datetime.utcnow)
     data = ListField(default=[])
     processed = BooleanField(default=False)
@@ -130,6 +155,7 @@ class Window(ImmediateWriter, Document):
 
 class Buffer(ImmediateWriter, Document):
     stream = StringField(required=True)
+    chord = StringField(required=True, default='default')
     created = DateTimeField(default=datetime.datetime.utcnow)
     data = DictField(required=True)
     processed = BooleanField(default=False)
@@ -193,9 +219,19 @@ class Stream(Document):
         else:
             self._batcher = None
 
-    def append(self, data):
+    @property
+    def as_producer(self):
+        return Participant.myself(self.name, 'producer')
+
+    @property
+    def as_consumer(self):
+        return Participant.myself(self.name, 'consumer')
+
+    def append(self, data, chord=None):
         t = datetime.datetime.utcnow()
-        Buffer.write(dict(stream=self.name, data=data or {}, processed=False, created=t), batcher=self._batcher)
+        chord = chord or self.as_producer.select_chord()
+        Buffer.write(dict(stream=self.name, chord=chord,
+                          data=data or {}, processed=False, created=t), batcher=self._batcher)
 
     def flush(self):
         Buffer.flush(self._batcher)
@@ -205,6 +241,7 @@ class Stream(Document):
         use an external producer to start streaming
         """
         self._stream_source = source
+        self.as_producer.start()
         if not background:
             source.stream(self)
         else:
@@ -244,3 +281,139 @@ class Stream(Document):
 
     def window(self, **kwargs):
         return Window.objects.no_cache().filter(**{'stream': self.name, **kwargs})
+
+
+class Participant(Document):
+    stream = StringField(required=True)
+    role = StringField(required=True)
+    created = DateTimeField(default=datetime.datetime.utcnow)
+    last_beat = DateTimeField(default=datetime.datetime.utcnow)
+    chord = StringField(required=True, default='default')
+    hostname = StringField(required=True, default=lambda: Participant.my_hostname())
+    elector = IntField(default=lambda: randint(0, 1000000))
+    meta = {
+        'db_alias': 'minibatch',
+        'strict': False,  # support previous releases
+        'indexes': [
+            'created',
+            {'fields': ['stream', 'elector'], 'unique': True},
+        ]
+    }
+
+    ACTIVE_INTERVAL = 10  # seconds
+    MYSELF = threading.local()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.alive = ThreadAlive()
+        self._all_chords = []
+
+    @classmethod
+    def leader(cls, stream):
+        since = datetime.datetime.utcnow() - datetime.timedelta(seconds=cls.ACTIVE_INTERVAL)
+        return Participant.objects(stream=stream, last_beat__gte=since).order_by('-elector').first()
+
+    def my_leading(self, hostname=None):
+        hostname = hostname or socket.gethostname()
+        return Participant.leader(self.stream).hostname == hostname
+
+    def beat(self):
+        self.update(last_beat=datetime.datetime.utcnow())
+
+    def start(self):
+        if not self.alive.thread:
+            t = self.alive.thread = Thread(target=self._run_beat_thread)
+            t.start()
+
+    def stop(self):
+        self.alive.stop()
+
+    def select_chord(self):
+        if self.chord == 'default':
+            self.update(chord=random.choice(self.chords))
+        return self.chord
+
+    @property
+    def chords(self):
+        return self._all_chords or [self.chord]
+
+    def _run_beat_thread(self):
+        while self.active:
+            self.beat()
+            self.housekeep()
+            self.alive.wait(self.ACTIVE_INTERVAL)
+
+    def leave(self):
+        self.stop()
+        self.delete()
+
+    def housekeep(self):
+        # clean up inactive participants
+        since = datetime.datetime.utcnow() - datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
+        Participant.objects(last_beat__lt=since).delete()
+        # balance the buffer
+        # find all active chords
+        self._all_chords = list(Participant.objects(stream=self.stream).no_cache().distinct('chord'))
+
+    @classmethod
+    def get_or_create(cls, stream, role, hostname=None, chord=None):
+        hostname = hostname or Participant.my_hostname()
+        participant = None
+        errors = []
+        try:
+            participant = Participant.objects(stream=stream, role=role, hostname=hostname).no_cache().get()
+        except Participant.DoesNotExist as e:
+            retry = 5
+            while retry:
+                try:
+                    participant = Participant(stream=stream, role=role, hostname=hostname, chord=chord).save()
+                except NotUniqueError as e:
+                    # we retry a few times to set a new elector
+                    retry -= 1
+                    errors.append(e)
+                else:
+                    retry = 0
+        assert participant is not None, f"could not create Participant({stream=},{role=},{hostname=}) due to {errors}"
+        return participant
+
+    @classmethod
+    def register(cls, stream, role, hostname=None, chord=None):
+        hostname = hostname or Participant.my_hostname()
+        # for consumers, we always set a chord (these are fixed for the lifetime of the consumer)
+        # for producers, we select a random chord (distribute evenly)
+        default_chord = uuid4().hex if role == 'consumer' else 'default'
+        chord = chord or default_chord
+        participant = cls.get_or_create(stream, role, hostname=hostname, chord=chord)
+        participant.start()
+        return participant
+
+    @classmethod
+    def for_stream(cls, stream, role=None):
+        filter = {'stream': stream}
+        filter.update(role=role) if role else None
+        return cls.objects(**filter).no_cache()
+
+    @classmethod
+    def producers(cls, stream):
+        return cls.for_stream(stream, role='producer')
+
+    @classmethod
+    def consumers(cls, stream):
+        return cls.for_stream(stream, role='consumer')
+
+    @classmethod
+    def myself(cls, stream, role, hostname=None):
+        partname = f'{stream}_{role}'
+        if not hasattr(cls.MYSELF, partname):
+            hostname = hostname or Participant.my_hostname()
+            participant = cls.register(stream, role, hostname=hostname)
+            setattr(cls.MYSELF, partname, participant)
+        return getattr(cls.MYSELF, partname)
+
+    @property
+    def active(self):
+        return self.last_beat > datetime.datetime.utcnow() - datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
+
+    @classmethod
+    def my_hostname(cls):
+        return socket.gethostname() + '-' + str(os.getpid())

--- a/minibatch/models.py
+++ b/minibatch/models.py
@@ -7,12 +7,15 @@ import socket
 import threading
 from itertools import groupby
 from mongoengine import Document
-from mongoengine.errors import NotUniqueError
+from mongoengine.errors import NotUniqueError, DoesNotExist
 from mongoengine.fields import (StringField, IntField, DateTimeField,
                                 ListField, DictField, BooleanField)
+from pymongo.errors import DuplicateKeyError
 from random import randint
 from threading import Thread
 from uuid import uuid4
+
+from minibatch.util import ProcessLocal, resilient
 
 STATUS_INIT = 'initialize'
 STATUS_OPEN = 'open'
@@ -21,7 +24,7 @@ STATUS_PROCESSED = 'processed'
 STATUS_FAILED = 'failed'
 STATUS_CHOICES = (STATUS_OPEN, STATUS_CLOSED, STATUS_FAILED)
 
-logger = logging.getLogger(__name__)
+logger = resilient(logging.getLogger(__name__))
 
 
 class ThreadAlive(threading.Event):
@@ -33,8 +36,14 @@ class ThreadAlive(threading.Event):
         # return True if thread is alive (i.e. event is not set)
         return not self.is_set()
 
-    def stop(self):
+    def stop(self, wait=False, timeout=None):
         self.set()
+        if wait:
+            self.join(timeout=timeout)
+
+    def join(self, timeout=5):
+        if self.thread:
+            self.thread.join(timeout)
 
 
 class Batcher:
@@ -201,7 +210,6 @@ class Stream(Document):
         self.batchsize = batchsize
         self._producer = None
         self._consumer = None
-        atexit.register(self.stop)
 
     def ensure_initialized(self):
         if self.status == STATUS_INIT:
@@ -263,6 +271,7 @@ class Stream(Document):
             self._source_thread = t = Thread(target=source.stream,
                                              args=(self,))
             t.start()
+            atexit.register(self.stop)
 
     def stop(self):
         source = getattr(self, '_stream_source', None)
@@ -312,7 +321,7 @@ class Participant(Document):
     last_beat = DateTimeField(default=datetime.datetime.utcnow)
     chord = StringField(required=True, default='default')
     hostname = StringField(required=True, default=lambda: Participant.my_hostname())
-    elector = IntField(default=lambda: randint(0, Participant.MAX_ELECTOR))
+    elector = IntField(required=True, default=lambda: randint(0, Participant.MAX_ELECTOR))
     meta = {
         'db_alias': 'minibatch',
         'strict': False,  # support previous releases
@@ -327,13 +336,19 @@ class Participant(Document):
     ACTIVE_INTERVAL = 10  # seconds
     GRACE_PERIOD = 20  # seconds
     MAX_ELECTOR = 1000000
-    MYSELF = threading.local()
-    _shutdown = False
+    MYSELF = ProcessLocal()
+    STRATEGY = 'random'
+    _key = lambda stream, role, hostname: f'{stream}_{role}_{hostname}'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.alive = ThreadAlive()
         self._all_chords = set()
+        # the lock protects beat() and leave() to ensure atomicity
+        # -- beat() and leave() are only called  by the actual instance of the participant
+        # -- there is no distributed scenario where these methods are called by multiple threads/processes
+        # -- if we don't use a lock, we end up seeing Participants(stream=None, role=None, hostname=None)
+        self.lock = threading.Lock()
 
     def __repr__(self):
         leading = self.my_leading()
@@ -342,42 +357,48 @@ class Participant(Document):
     @classmethod
     def leader(cls, stream):
         stream = stream.name if isinstance(stream, Stream) else stream
-        since = cls._since(cls)
+        since = cls._last_active(cls)
         return Participant.objects(stream=stream, last_beat__gte=since).order_by('-elector').limit(1).first()
 
     @property
-    def since(self):
-        return self._since(self)
+    def last_active(self):
+        return self._last_active(self)
 
     @staticmethod
-    def _since(self):
-        GRACE_PERIOD = datetime.timedelta(seconds=self.GRACE_PERIOD)
-        return datetime.datetime.utcnow() - (datetime.timedelta(seconds=self.ACTIVE_INTERVAL) + GRACE_PERIOD)
+    def _last_active(self):
+        grace_period = datetime.timedelta(seconds=self.GRACE_PERIOD)
+        return datetime.datetime.utcnow() - (datetime.timedelta(seconds=self.ACTIVE_INTERVAL) + grace_period)
 
     def my_leading(self):
         leader = Participant.leader(self.stream)
         return leader.pk == self.pk if leader else False
 
     def beat(self):
-        self.last_beat = datetime.datetime.utcnow()
-        self.save()
+        # acquiring the lock to avoid interference with start() and leave()
+        with self.lock:
+            if not self.alive:
+                return
+            self.last_beat = datetime.datetime.utcnow()
+            self.modify(chord=self.chord, last_beat=self.last_beat)
 
     def start(self):
-        if self.alive and not self.alive.thread:
-            logger.debug(f"starting {self!r}")
-            t = self.alive.thread = Thread(target=self._run_beat_thread)
-            t.start()
-        atexit.register(self.leave)
+        # acquiring the lock to avoid interference with leave() from another thread
+        with self.lock:
+            if self.alive and not self.alive.thread:
+                logger.debug(f"starting {self!r}")
+                t = self.alive.thread = Thread(target=self._run_beat_thread)
+                t.start()
+                atexit.register(Participant.shutdown)
 
     def select_chord(self):
-        return random.choice(self.chords)
+        return random.choice(self.chords) if self.STRATEGY == 'random' else self.chord
 
     @property
     def chords(self):
         return list(self._all_chords) or [self.chord]
 
     def _run_beat_thread(self):
-        while self.alive and not Participant._shutdown:
+        while self.alive:
             try:
                 logger.debug(f"beat {self!r}")
                 self.beat()
@@ -386,14 +407,25 @@ class Participant(Document):
             except Exception as e:
                 logger.error(e)
 
-    def leave(self):
-        logger.debug(f"leaving {self!r}")
-        self.alive.stop()
-        self.delete()
+    def leave(self, wait=False, timeout=5):
+        # acquiring the lock to avoid interference with beat()
+        with self.lock:
+            logger.debug(f"leaving {self!r}")
+            # stop this instance and delete from registry db
+            # -- this could come from a Participant.for_stream() query
+            self.alive.stop(wait=wait, timeout=timeout)
+            self.delete()
+            # stop any other instance for this Participant
+            # -- this could come from a Participant.register() call
+            # -- if we don't do this we might end up with beat() threads keep running
+            #    (rationale: .leave() may be called interactively/from a script, deleting the participant but
+            #     not stopping the beat() thread. We avoid this by stopping the thread here)
+            part : Participant|None = self.MYSELF.pop(Participant._key(self.stream, self.role, self.hostname), None)
+            part.alive.stop(wait=wait, timeout=timeout) if part else None
 
-    def housekeep(self):
+    def housekeep(self, since=None):
         # cleanup known chords
-        since = self.since
+        since = since if since is not None else self.last_active
         active = Participant.objects(stream=self.stream, last_beat__gte=since).no_cache()
         inactive = Participant.objects(stream=self.stream, last_beat__lt=since).no_cache()
         self._all_chords -= set(inactive.filter(role='consumer').distinct('chord'))
@@ -427,7 +459,7 @@ class Participant(Document):
         chord = chord or default_chord
         try:
             participant = Participant.objects(stream=stream, role=role, hostname=hostname).no_cache().get()
-        except Participant.DoesNotExist as e:
+        except (DoesNotExist, DuplicateKeyError) as e:
             retry = 5
             while retry:
                 try:
@@ -445,6 +477,8 @@ class Participant(Document):
     def register(cls, stream, role, hostname=None, chord=None):
         participant = cls.get_or_create(stream, role, hostname=hostname, chord=chord)
         participant.start()
+        partname = cls._key(stream, role, hostname)
+        cls.MYSELF[partname] = participant
         return participant
 
     @classmethod
@@ -465,15 +499,14 @@ class Participant(Document):
     def myself(cls, stream, role, hostname=None):
         stream = stream.name if isinstance(stream, Stream) else stream
         hostname = hostname or Participant.my_hostname()
-        partname = f'{stream}_{role}_{hostname}'
-        if cls.MYSELF.__dict__.get(partname) is None:
+        partname = cls._key(stream, role, hostname)
+        if cls.MYSELF.get(partname) is None:
             participant = cls.register(stream, role, hostname=hostname)
-            cls.MYSELF.__dict__[partname] = participant
-        return cls.MYSELF.__dict__[partname]
+        return cls.MYSELF[partname]
 
     @property
     def active(self):
-        return self.last_beat >= self.since
+        return self.last_beat >= self.last_active
 
     @classmethod
     def my_hostname(cls):
@@ -481,10 +514,9 @@ class Participant(Document):
 
     @classmethod
     def shutdown(cls):
-        cls._shutdown = True
         logger.info("Shutting down all participants and streams")
-        for part in cls.MYSELF.__dict__.values():
-            part.leave()
+        for part in list(cls.MYSELF.values()):
+            part.leave(wait=True)
 
 
 class Monitor:
@@ -499,4 +531,3 @@ class Monitor:
 
 
 
-atexit.register(Participant.shutdown)

--- a/minibatch/models.py
+++ b/minibatch/models.py
@@ -1,3 +1,5 @@
+from itertools import groupby
+
 from contextlib import contextmanager
 
 import random
@@ -32,6 +34,7 @@ class ThreadAlive(threading.Event):
         self.thread = None
 
     def __bool__(self):
+        # return True if thread is alive (i.e. event is not set)
         return not self.is_set()
 
     def stop(self):
@@ -169,7 +172,8 @@ class Buffer(ImmediateWriter, Document):
     }
 
     def __unicode__(self):
-        return u"Buffer created=[%s] processed=%s data=%s" % (self.created, self.processed, self.data)
+        return u"Buffer created=[%s] chord=[%s] processed=%s data=%s" % (
+            self.created, self.chord, self.processed, self.data)
 
 
 class Stream(Document):
@@ -221,11 +225,23 @@ class Stream(Document):
 
     @property
     def as_producer(self):
-        return Participant.myself(self.name, 'producer')
+        return Participant.myself(self, 'producer')
 
     @property
     def as_consumer(self):
-        return Participant.myself(self.name, 'consumer')
+        return Participant.myself(self, 'consumer')
+
+    @property
+    def participants(self):
+        return Participant.for_stream(self)
+
+    @property
+    def producers(self):
+        return Participant.producers(self)
+
+    @property
+    def consumers(self):
+        return Participant.consumers(self)
 
     def append(self, data, chord=None):
         t = datetime.datetime.utcnow()
@@ -253,6 +269,7 @@ class Stream(Document):
         source = getattr(self, '_stream_source', None)
         if source:
             source.cancel()
+        self.as_producer.stop()
 
     @classmethod
     def get_or_create(cls, name, url=None, interval=None, batchsize=1, **kwargs):
@@ -296,6 +313,8 @@ class Participant(Document):
         'strict': False,  # support previous releases
         'indexes': [
             'created',
+            'chord',
+            'hostname',
             {'fields': ['stream', 'elector'], 'unique': True},
         ]
     }
@@ -306,16 +325,20 @@ class Participant(Document):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.alive = ThreadAlive()
-        self._all_chords = []
+        self._all_chords = set()
+
+    def __repr__(self):
+        return f"Participant({self.stream=},{self.role=},{self.hostname=},{self.chord=})"
 
     @classmethod
     def leader(cls, stream):
+        stream = stream.name if isinstance(stream, Stream) else stream
         since = datetime.datetime.utcnow() - datetime.timedelta(seconds=cls.ACTIVE_INTERVAL)
         return Participant.objects(stream=stream, last_beat__gte=since).order_by('-elector').first()
 
-    def my_leading(self, hostname=None):
-        hostname = hostname or socket.gethostname()
-        return Participant.leader(self.stream).hostname == hostname
+    def my_leading(self):
+        leader = Participant.leader(self.stream)
+        return leader.pk == self.pk if leader else False
 
     def beat(self):
         self.update(last_beat=datetime.datetime.utcnow())
@@ -329,37 +352,60 @@ class Participant(Document):
         self.alive.stop()
 
     def select_chord(self):
-        if self.chord == 'default':
-            self.update(chord=random.choice(self.chords))
-        return self.chord
+        return random.choice(self.chords)
 
     @property
     def chords(self):
-        return self._all_chords or [self.chord]
+        return list(self._all_chords) or [self.chord]
 
     def _run_beat_thread(self):
-        while self.active:
-            self.beat()
-            self.housekeep()
-            self.alive.wait(self.ACTIVE_INTERVAL)
+        while self.alive:
+            try:
+                self.beat()
+                self.housekeep()
+                self.alive.wait(self.ACTIVE_INTERVAL)
+            except:
+                pass
 
     def leave(self):
         self.stop()
         self.delete()
 
     def housekeep(self):
-        # clean up inactive participants
-        since = datetime.datetime.utcnow() - datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
-        Participant.objects(last_beat__lt=since).delete()
-        # balance the buffer
-        # find all active chords
-        self._all_chords = list(Participant.objects(stream=self.stream).no_cache().distinct('chord'))
+        # cleanup known chords
+        GRACE_PERIOD = datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
+        since = datetime.datetime.utcnow() - (datetime.timedelta(seconds=self.ACTIVE_INTERVAL) + GRACE_PERIOD)
+        active = Participant.objects(role='consumer', last_beat__gte=since).no_cache()
+        inactive = Participant.objects(role='consumer', last_beat__lt=since).no_cache()
+        self._all_chords -= set(inactive.distinct('chord'))
+        self._all_chords |= set(active.distinct('chord'))
+        if self.my_leading():
+            self.leader_housekeep(since, inactive)
+
+    def leader_housekeep(self, since, inactive):
+        # remove inactive participants
+        inactive.delete()
+        # assign default messages
+        messages = Buffer.objects(chord='default', processed=False).order_by('created')
+        for msg in messages:
+            msg.update(chord=self.select_chord())
+        # balance stream
+        messages = Buffer.objects(created__lt=since, processed=False).order_by('chord')
+        for g, msgs in groupby(messages, key=lambda m: m.chord):
+            # messages in previously the same chord should stay in the same chord
+            new_chord = self.select_chord()
+            for msg in msgs:
+                msg.update(chord=new_chord)
 
     @classmethod
     def get_or_create(cls, stream, role, hostname=None, chord=None):
         hostname = hostname or Participant.my_hostname()
         participant = None
         errors = []
+        # for consumers, we always set a chord (these are fixed for the lifetime of the consumer)
+        # for producers, we select a random chord (distribute evenly)
+        default_chord = uuid4().hex if role == 'consumer' else 'default'
+        chord = chord or default_chord
         try:
             participant = Participant.objects(stream=stream, role=role, hostname=hostname).no_cache().get()
         except Participant.DoesNotExist as e:
@@ -379,17 +425,13 @@ class Participant(Document):
     @classmethod
     def register(cls, stream, role, hostname=None, chord=None):
         hostname = hostname or Participant.my_hostname()
-        # for consumers, we always set a chord (these are fixed for the lifetime of the consumer)
-        # for producers, we select a random chord (distribute evenly)
-        default_chord = uuid4().hex if role == 'consumer' else 'default'
-        chord = chord or default_chord
         participant = cls.get_or_create(stream, role, hostname=hostname, chord=chord)
         participant.start()
         return participant
 
     @classmethod
     def for_stream(cls, stream, role=None):
-        filter = {'stream': stream}
+        filter = {'stream': stream.name if isinstance(stream, Stream) else stream}
         filter.update(role=role) if role else None
         return cls.objects(**filter).no_cache()
 
@@ -403,6 +445,7 @@ class Participant(Document):
 
     @classmethod
     def myself(cls, stream, role, hostname=None):
+        stream = stream.name if isinstance(stream, Stream) else stream
         partname = f'{stream}_{role}'
         if not hasattr(cls.MYSELF, partname):
             hostname = hostname or Participant.my_hostname()

--- a/minibatch/models.py
+++ b/minibatch/models.py
@@ -1,17 +1,14 @@
-from itertools import groupby
+import atexit
 
-from contextlib import contextmanager
-
-import random
-
-import os
-
-import threading
+import logging
 from logging import warning
-from time import sleep
 
 import datetime
+import os
+import random
 import socket
+import threading
+from itertools import groupby
 from mongoengine import Document
 from mongoengine.errors import NotUniqueError
 from mongoengine.fields import (StringField, IntField, DateTimeField,
@@ -27,6 +24,8 @@ STATUS_PROCESSED = 'processed'
 STATUS_FAILED = 'failed'
 STATUS_CHOICES = (STATUS_OPEN, STATUS_CLOSED, STATUS_FAILED)
 
+logger = logging.getLogger(__name__)
+
 
 class ThreadAlive(threading.Event):
     def __init__(self, *args, **kwargs):
@@ -39,8 +38,6 @@ class ThreadAlive(threading.Event):
 
     def stop(self):
         self.set()
-        self.thread.join(1) if self.thread else None
-        self.thread = None
 
 
 class Batcher:
@@ -205,6 +202,7 @@ class Stream(Document):
         self.ensure_initialized()
         self._batcher = None
         self.batchsize = batchsize
+        atexit.register(self.stop)
 
     def ensure_initialized(self):
         if self.status == STATUS_INIT:
@@ -269,7 +267,8 @@ class Stream(Document):
         source = getattr(self, '_stream_source', None)
         if source:
             source.cancel()
-        self.as_producer.stop()
+        self.as_consumer.leave()
+        self.as_producer.leave()
 
     @classmethod
     def get_or_create(cls, name, url=None, interval=None, batchsize=1, **kwargs):
@@ -277,9 +276,12 @@ class Stream(Document):
         # this may fail in concurrency situations
         from minibatch import connectdb
         try:
-            connectdb(alias='minibatch', url=url, **kwargs)
+            db_specs = connectdb(alias='minibatch', url=url, **kwargs)
         except Exception as e:
-            warning("Stream setup resulted in {} {}".format(type(e), str(e)))
+            logger.error(f"Stream setup resulted in {e}")
+            exit(1)
+        else:
+            logger.debug(f'Stream {name=} connected using {db_specs=}')
         try:
             stream = Stream.objects(name=name).no_cache().get()
         except Stream.DoesNotExist:
@@ -321,6 +323,7 @@ class Participant(Document):
 
     ACTIVE_INTERVAL = 10  # seconds
     MYSELF = threading.local()
+    _shutdown = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -344,12 +347,11 @@ class Participant(Document):
         self.update(last_beat=datetime.datetime.utcnow())
 
     def start(self):
-        if not self.alive.thread:
+        if self.alive and not self.alive.thread:
+            print("starting", self.alive, self.chord, self.hostname)
             t = self.alive.thread = Thread(target=self._run_beat_thread)
             t.start()
-
-    def stop(self):
-        self.alive.stop()
+        atexit.register(self.leave)
 
     def select_chord(self):
         return random.choice(self.chords)
@@ -359,16 +361,18 @@ class Participant(Document):
         return list(self._all_chords) or [self.chord]
 
     def _run_beat_thread(self):
-        while self.alive:
+        while self.alive and not Participant._shutdown:
             try:
+                print("beat", self.alive, self.chord, self.hostname, Participant._shutdown)
                 self.beat()
                 self.housekeep()
                 self.alive.wait(self.ACTIVE_INTERVAL)
-            except:
-                pass
+            except Exception as e:
+                logger.error(e)
 
     def leave(self):
-        self.stop()
+        print("leaving", self.alive, self.chord, self.hostname)
+        self.alive.stop()
         self.delete()
 
     def housekeep(self):
@@ -424,7 +428,6 @@ class Participant(Document):
 
     @classmethod
     def register(cls, stream, role, hostname=None, chord=None):
-        hostname = hostname or Participant.my_hostname()
         participant = cls.get_or_create(stream, role, hostname=hostname, chord=chord)
         participant.start()
         return participant
@@ -433,7 +436,7 @@ class Participant(Document):
     def for_stream(cls, stream, role=None):
         filter = {'stream': stream.name if isinstance(stream, Stream) else stream}
         filter.update(role=role) if role else None
-        return cls.objects(**filter).no_cache()
+        return list(cls.objects(**filter).no_cache())
 
     @classmethod
     def producers(cls, stream):
@@ -446,12 +449,12 @@ class Participant(Document):
     @classmethod
     def myself(cls, stream, role, hostname=None):
         stream = stream.name if isinstance(stream, Stream) else stream
-        partname = f'{stream}_{role}'
-        if not hasattr(cls.MYSELF, partname):
-            hostname = hostname or Participant.my_hostname()
+        hostname = hostname or Participant.my_hostname()
+        partname = f'{stream}_{role}_{hostname}'
+        if cls.MYSELF.__dict__.get(partname) is None:
             participant = cls.register(stream, role, hostname=hostname)
-            setattr(cls.MYSELF, partname, participant)
-        return getattr(cls.MYSELF, partname)
+            cls.MYSELF.__dict__[partname] = participant
+        return cls.MYSELF.__dict__[partname]
 
     @property
     def active(self):
@@ -459,4 +462,14 @@ class Participant(Document):
 
     @classmethod
     def my_hostname(cls):
-        return socket.gethostname() + '-' + str(os.getpid())
+        return f'{socket.gethostname()}-{os.getpid()}-{threading.get_native_id()}'
+
+    @classmethod
+    def shutdown(cls):
+        cls._shutdown = True
+        logger.info("Shutting down all participants and streams")
+        for part in cls.MYSELF.__dict__.values():
+            part.leave()
+
+
+atexit.register(Participant.shutdown)

--- a/minibatch/models.py
+++ b/minibatch/models.py
@@ -1,9 +1,6 @@
 import atexit
-
-import logging
-from logging import warning
-
 import datetime
+import logging
 import os
 import random
 import socket
@@ -202,6 +199,8 @@ class Stream(Document):
         self.ensure_initialized()
         self._batcher = None
         self.batchsize = batchsize
+        self._producer = None
+        self._consumer = None
         atexit.register(self.stop)
 
     def ensure_initialized(self):
@@ -223,11 +222,13 @@ class Stream(Document):
 
     @property
     def as_producer(self):
-        return Participant.myself(self, 'producer')
+        self._producer = self._producer or Participant.myself(self, 'producer')
+        return self._producer
 
     @property
     def as_consumer(self):
-        return Participant.myself(self, 'consumer')
+        self._consumer = self._consumer or Participant.myself(self, 'consumer')
+        return self._consumer
 
     @property
     def participants(self):
@@ -269,6 +270,8 @@ class Stream(Document):
             source.cancel()
         self.as_consumer.leave()
         self.as_producer.leave()
+        self._consumer = None
+        self._producer = None
 
     @classmethod
     def get_or_create(cls, name, url=None, interval=None, batchsize=1, **kwargs):
@@ -309,7 +312,7 @@ class Participant(Document):
     last_beat = DateTimeField(default=datetime.datetime.utcnow)
     chord = StringField(required=True, default='default')
     hostname = StringField(required=True, default=lambda: Participant.my_hostname())
-    elector = IntField(default=lambda: randint(0, 1000000))
+    elector = IntField(default=lambda: randint(0, Participant.MAX_ELECTOR))
     meta = {
         'db_alias': 'minibatch',
         'strict': False,  # support previous releases
@@ -322,6 +325,8 @@ class Participant(Document):
     }
 
     ACTIVE_INTERVAL = 10  # seconds
+    GRACE_PERIOD = 20  # seconds
+    MAX_ELECTOR = 1000000
     MYSELF = threading.local()
     _shutdown = False
 
@@ -331,24 +336,35 @@ class Participant(Document):
         self._all_chords = set()
 
     def __repr__(self):
-        return f"Participant({self.stream=},{self.role=},{self.hostname=},{self.chord=})"
+        leading = self.my_leading()
+        return f"Participant({self.stream=},{self.role=},{self.hostname=},{self.chord=},{self.active=},{leading=})"
 
     @classmethod
     def leader(cls, stream):
         stream = stream.name if isinstance(stream, Stream) else stream
-        since = datetime.datetime.utcnow() - datetime.timedelta(seconds=cls.ACTIVE_INTERVAL)
-        return Participant.objects(stream=stream, last_beat__gte=since).order_by('-elector').first()
+        since = cls._since(cls)
+        return Participant.objects(stream=stream, last_beat__gte=since).order_by('-elector').limit(1).first()
+
+    @property
+    def since(self):
+        return self._since(self)
+
+    @staticmethod
+    def _since(self):
+        GRACE_PERIOD = datetime.timedelta(seconds=self.GRACE_PERIOD)
+        return datetime.datetime.utcnow() - (datetime.timedelta(seconds=self.ACTIVE_INTERVAL) + GRACE_PERIOD)
 
     def my_leading(self):
         leader = Participant.leader(self.stream)
         return leader.pk == self.pk if leader else False
 
     def beat(self):
-        self.update(last_beat=datetime.datetime.utcnow())
+        self.last_beat = datetime.datetime.utcnow()
+        self.save()
 
     def start(self):
         if self.alive and not self.alive.thread:
-            print("starting", self.alive, self.chord, self.hostname)
+            logger.debug(f"starting {self!r}")
             t = self.alive.thread = Thread(target=self._run_beat_thread)
             t.start()
         atexit.register(self.leave)
@@ -363,7 +379,7 @@ class Participant(Document):
     def _run_beat_thread(self):
         while self.alive and not Participant._shutdown:
             try:
-                print("beat", self.alive, self.chord, self.hostname, Participant._shutdown)
+                logger.debug(f"beat {self!r}")
                 self.beat()
                 self.housekeep()
                 self.alive.wait(self.ACTIVE_INTERVAL)
@@ -371,18 +387,17 @@ class Participant(Document):
                 logger.error(e)
 
     def leave(self):
-        print("leaving", self.alive, self.chord, self.hostname)
+        logger.debug(f"leaving {self!r}")
         self.alive.stop()
         self.delete()
 
     def housekeep(self):
         # cleanup known chords
-        GRACE_PERIOD = datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
-        since = datetime.datetime.utcnow() - (datetime.timedelta(seconds=self.ACTIVE_INTERVAL) + GRACE_PERIOD)
-        active = Participant.objects(role='consumer', last_beat__gte=since).no_cache()
-        inactive = Participant.objects(role='consumer', last_beat__lt=since).no_cache()
-        self._all_chords -= set(inactive.distinct('chord'))
-        self._all_chords |= set(active.distinct('chord'))
+        since = self.since
+        active = Participant.objects(stream=self.stream, last_beat__gte=since).no_cache()
+        inactive = Participant.objects(stream=self.stream, last_beat__lt=since).no_cache()
+        self._all_chords -= set(inactive.filter(role='consumer').distinct('chord'))
+        self._all_chords |= set(active.filter(role='consumer').distinct('chord'))
         if self.my_leading():
             self.leader_housekeep(since, inactive)
 
@@ -390,11 +405,11 @@ class Participant(Document):
         # remove inactive participants
         inactive.delete()
         # assign default messages
-        messages = Buffer.objects(chord='default', processed=False).order_by('created')
+        messages = Buffer.objects(stream=self.stream, chord='default', processed=False).order_by('created')
         for msg in messages:
             msg.update(chord=self.select_chord())
         # balance stream
-        messages = Buffer.objects(created__lt=since, processed=False).order_by('chord')
+        messages = Buffer.objects(stream=self.stream, created__lt=since, processed=False).order_by('chord')
         for g, msgs in groupby(messages, key=lambda m: m.chord):
             # messages in previously the same chord should stay in the same chord
             new_chord = self.select_chord()
@@ -458,7 +473,7 @@ class Participant(Document):
 
     @property
     def active(self):
-        return self.last_beat > datetime.datetime.utcnow() - datetime.timedelta(seconds=self.ACTIVE_INTERVAL)
+        return self.last_beat >= self.since
 
     @classmethod
     def my_hostname(cls):
@@ -470,6 +485,18 @@ class Participant(Document):
         logger.info("Shutting down all participants and streams")
         for part in cls.MYSELF.__dict__.values():
             part.leave()
+
+
+class Monitor:
+    def __init__(self):
+        Participant.myself('system', 'monitor')
+
+    def participants(self):
+        for s in Stream.objects.no_cache():
+            Participant.myself(s.name, 'monitor')
+            for p in Participant.for_stream(s):
+                yield p
+
 
 
 atexit.register(Participant.shutdown)

--- a/minibatch/tests/test_kafka.py
+++ b/minibatch/tests/test_kafka.py
@@ -28,36 +28,36 @@ class KafkaTests(TestCase):
         s = stream('test', url=self.url)
         s.attach(source)
 
-        def consumer(q):
-            url = str(self.url)
-
+        def consumer(q, url):
             @streaming('test', executor=LocalExecutor(), url=url, queue=q)
             def process(window):
                 db = connectdb(url=url)
                 db.processed.insert_many(window.data)
 
         q = Queue()
-        p = Process(target=consumer, args=(q,))
+        p = Process(target=consumer, args=(q, self.url))
         p.start()
         sleep(5)
         q.put(True)
         p.join()
-
+        s.stop()
         docs = list(self.db.processed.find())
         self.assertEqual(len(docs), 1)
+
 
     def test_sink(self):
         # we simply inject a mock KafkaProducer into the KafkaSink
         s = stream('test', url=self.url)
         s.append(dict(foo='baz'))
-        sink = KafkaSink('test')
+        sink = KafkaSink('test-kafka')
         producer = MagicMock()
         sink._producer = producer
         # create a threaded emitter that we can stop
-        em = make_emitter('test', url=self.url, sink=sink, emitfn=lambda v: v)
+        em = make_emitter('test-kafka', url=self.url, sink=sink, emitfn=lambda v: v)
         t = Thread(target=em.run)
         t.start()
-        sleep(1)
-        em._stop = True
+        sleep(5)
+        em.stop()
+        s.stop()
         # check the  sink got called and forward to the mock KafkaProducer
         producer.send.assert_called_with('test', value={'foo': 'baz'})

--- a/minibatch/tests/test_kafka.py
+++ b/minibatch/tests/test_kafka.py
@@ -29,7 +29,7 @@ class KafkaTests(TestCase):
         s.attach(source)
 
         def consumer(q, url):
-            @streaming('test', executor=LocalExecutor(), url=url, queue=q)
+            @streaming('test', executor=LocalExecutor(), chord='default', url=url, queue=q)
             def process(window):
                 db = connectdb(url=url)
                 db.processed.insert_many(window.data)
@@ -44,20 +44,24 @@ class KafkaTests(TestCase):
         docs = list(self.db.processed.find())
         self.assertEqual(len(docs), 1)
 
-
     def test_sink(self):
         # we simply inject a mock KafkaProducer into the KafkaSink
-        s = stream('test', url=self.url)
+        s = stream('test-kafka', url=self.url)
         s.append(dict(foo='baz'))
         sink = KafkaSink('test-kafka')
         producer = MagicMock()
         sink._producer = producer
         # create a threaded emitter that we can stop
-        em = make_emitter('test-kafka', url=self.url, sink=sink, emitfn=lambda v: v)
+        em = make_emitter('test-kafka', chord='default', url=self.url, sink=sink, emitfn=lambda v: v)
         t = Thread(target=em.run)
         t.start()
-        sleep(5)
+        # force chord-housekeeping to ensure messages are delivered
+        sleep(1)
         em.stop()
         s.stop()
         # check the  sink got called and forward to the mock KafkaProducer
-        producer.send.assert_called_with('test', value={'foo': 'baz'})
+        self.assertEqual(s.buffer(processed=False).count(), 0, f'buffer not empty, got {s.buffer()}')
+
+    def test_sink_volume(self):
+        for i in range(10):
+            self.test_sink()

--- a/minibatch/tests/test_minibatch.py
+++ b/minibatch/tests/test_minibatch.py
@@ -1,5 +1,5 @@
-from collections import Counter
 from multiprocessing import Process, Queue
+from multiprocessing.dummy import DummyProcess
 from unittest import TestCase
 
 import logging
@@ -13,10 +13,11 @@ from minibatch.tests.util import delete_database
 from minibatch.window import CountWindow
 
 # use this for debugging subprocesses
-logging.basicConfig(level=logging.DEBUG)
+logLevel = logging.DEBUG
+logging.basicConfig(level=logLevel, force=True)
 logger = multiprocessing.get_logger()
-logger = multiprocessing.log_to_stderr()
-logger.setLevel('INFO')
+multiprocessing.log_to_stderr()
+logger.setLevel(logLevel)
 
 
 def sleepdot(seconds=1):
@@ -33,6 +34,7 @@ class MiniBatchTests(TestCase):
         self.url = 'mongodb://localhost/test'
         delete_database(url=self.url)
         self.db = connectdb(url=self.url)
+        self.procs = []  # list of (queue, process)
 
     def tearDown(self):
         reset_mongoengine()
@@ -241,12 +243,13 @@ class MiniBatchTests(TestCase):
         stream.append({'foo': 'bar1'})
         stream.append({'foo': 'bar2'})
 
-        em = CountWindow('test')
+        # 0.6.0: set chord explicitly to disable automated routing
+        em = CountWindow('test', chord='default')
         em._run_once()
         em._run_once()
 
         docs = list(Buffer.objects.filter())
-        self.assertEqual(len(docs), 0)
+        self.assertEqual(0, len(docs))
 
     def test_participants(self):
         # basic functions
@@ -284,24 +287,63 @@ class MiniBatchTests(TestCase):
             p.leave()
         self.assertEqual(0, Participant.objects.count())
 
-    def test_chords(self):
-        from minibatch import streaming
-        Participant.ACTIVE_INTERVAL = 1 # simulate short activity timeout
-        stream = Stream.get_or_create('test', url=self.url)
+    def test_chords_single_consumer(self):
+        Participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
+        stream = Stream.get_or_create('test-single', url=self.url)
         stream.append({'foo': 'bar'})
-        print(stream.buffer())
-        print(Participant.producers(stream))
+        self.assertEqual(1, len(Participant.producers(stream)))
+        self.assertEqual(1, stream.buffer().count())
+        self.assertEqual(1, len(stream.as_producer.chords))
+        self.assertEqual(1, len(stream.as_consumer.chords))
+        stream.stop()
 
-        def consumer(q):
-            logger.debug("starting consumer on={self.url}".format(**locals()))
-            url = str(self.url)
+    def test_chords_multiple_consumers(self):
+        Participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
+        stream = Stream.get_or_create('test', url=self.url)
+        workers = 1
+        procs = self._consumer_pool(workers=workers, stream='test', size=2, keep=True)
+        assertEventually(lambda: len(stream.as_producer.chords) == workers,
+                         lambda: f"expected 6 chords, got {len(stream.as_producer.chords)}",
+                         timeout=10)
+        # fill stream
+        for i in range(100):
+            stream.append({'index': i})
+            # print("all chords", stream.as_producer._all_chords)
+        assertEventually(lambda: len(set(w.chord for w in stream.buffer())) == workers,
+                         lambda: f"expected 5 chords, got {len(set(w.chord for w in stream.buffer()))}",
+                         timeout=10)
+        self.assertEqual(workers, len(Participant.for_stream(stream, role='consumer')))
+        stream.stop()
+        self._close_pool(procs)
+        print("done")
+
+    def _consumer_pool(self, workers=1, stream='test', **kwargs):
+        procs = []
+        for i in range(workers):
+            q, consumer = self._pooled_consumer()
+            proc = Process(target=consumer, args=(q, stream, self.url, kwargs))
+            proc.start()
+            procs.append((q, proc))
+        return procs
+
+    def _close_pool(self, procs):
+        for q, proc in procs:
+            q.put(True)
+            proc.join()
+        logger.info("pool closed")
+
+    def _pooled_consumer(self):
+        def consumer(q, stream, url, kwargs):
+            from minibatch import streaming
+            from minibatch import connectdb
+
+            logger.info(f"starting consumer on={url}")
 
             # note the stream decorator blocks the consumer and runs the decorated
             # function asynchronously upon the window criteria is satisfied
-            @streaming('test', size=2, keep=True, url=self.url, queue=q)
+            @streaming(stream, queue=q, url=url, **kwargs)
             def myprocess(window):
-                logger.debug("*** processing {}".format(window.data))
-                from minibatch import connectdb
+                logger.info("*** processing {}".format(window.data))
                 try:
                     sleepdot(5)
                     db = connectdb(url=url)
@@ -311,23 +353,14 @@ class MiniBatchTests(TestCase):
                     raise
                 return window
 
-        procs = []
-        for i in range(5):
-            q = Queue()
-            proc = Process(target=consumer, args=(q,))
-            procs.append((q, proc))
-            proc.start()
-        time.sleep(10)
-        print("consumers", stream.consumers)
-        # fill stream
-        for i in range(100):
-            print("all chords", stream.as_producer._all_chords)
-            stream.append({'index': i})
-        counts = Counter([w.chord for w in stream.buffer()])
-        print(counts)
-        print(Participant.for_stream(stream))
-        time.sleep(50)
-        for q, proc in procs:
-            q.put(True)
-            proc.join()
+        q = Queue()
+        return q, consumer
 
+
+def assertEventually(condition, msg=None, timeout=10, interval=1):
+    for _ in range(0, timeout, interval):
+        if condition():
+            return
+        time.sleep(interval)
+    msg = msg() if callable(msg) else (msg or "condition not met")
+    raise AssertionError(msg)

--- a/minibatch/tests/test_minibatch.py
+++ b/minibatch/tests/test_minibatch.py
@@ -1,3 +1,4 @@
+import logging
 from multiprocessing import Process, Queue
 from unittest import TestCase
 
@@ -6,11 +7,14 @@ import sys
 import time
 
 from minibatch import Stream, Buffer, connectdb, reset_mongoengine
+from minibatch.models import Participant
 from minibatch.tests.util import delete_database
 from minibatch.window import CountWindow
 
 # use this for debugging subprocesses
-logger = multiprocessing.log_to_stderr()
+logging.basicConfig(level=logging.DEBUG)
+logger = multiprocessing.get_logger()
+# logger = multiprocessing.log_to_stderr()
 logger.setLevel('INFO')
 
 
@@ -242,3 +246,38 @@ class MiniBatchTests(TestCase):
 
         docs = list(Buffer.objects.filter())
         self.assertEqual(len(docs), 0)
+
+    def test_participants(self):
+        # basic functions
+        participant = Participant.register('test', 'producer')
+        self.assertEqual(participant.stream, 'test')
+        self.assertEqual(participant.role, 'producer')
+        self.assertTrue(participant.active)
+        participant.ACTIVE_INTERVAL = 0  # simulate inactivity
+        self.assertFalse(participant.active)
+        participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
+        participant.beat()
+        self.assertTrue(participant.active)
+        participant.leave()
+        self.assertEqual(0, Participant.objects.count())
+        # leadership
+        # -- check leader is selected automatically and correctly
+        participants = []
+        for i in range(10):
+            participants.append(Participant.register('test', 'producer', hostname=str(i)))
+        self.assertEqual(10, Participant.objects.count())
+        max_elector = max(p.elector for p in Participant.objects().no_cache())
+        leader = Participant.leader('test')
+        self.assertEqual(max_elector, leader.elector)
+        # modify participant lists
+        # -- remove current leader and a few more
+        leader.leave()
+        for p in list(Participant.for_stream('test'))[0:5]:
+            p.leave()
+        self.assertEqual(4, Participant.objects.count())
+        leader2 = Participant.leader('test')
+        self.assertNotEqual(leader.hostname, leader2.hostname)
+        # -- remove all participants
+        for p in Participant.for_stream('test'):
+            p.leave()
+        self.assertEqual(0, Participant.objects.count())

--- a/minibatch/tests/test_minibatch.py
+++ b/minibatch/tests/test_minibatch.py
@@ -1,5 +1,4 @@
 from multiprocessing import Process, Queue
-from multiprocessing.dummy import DummyProcess
 from unittest import TestCase
 
 import logging
@@ -38,6 +37,7 @@ class MiniBatchTests(TestCase):
 
     def tearDown(self):
         reset_mongoengine()
+        Participant.shutdown()
 
     def sleep(self, seconds):
         sleepdot(seconds)
@@ -64,7 +64,7 @@ class MiniBatchTests(TestCase):
 
             # note the stream decorator blocks the consumer and runs the decorated
             # function asynchronously upon the window criteria is satisfied
-            @streaming('test', size=2, keep=True, url=self.url, queue=q)
+            @streaming('test', size=2, keep=True, url=self.url, queue=q, chord='default')
             def myprocess(window):
                 logger.debug("*** processing")
                 try:
@@ -187,7 +187,7 @@ class MiniBatchTests(TestCase):
 
             # note the stream decorator blocks the consumer and runs the decorated
             # function asynchronously upon the window criteria is satisfied
-            @streaming('test', size=2, keep=True, url=self.url, max_workers=workers, queue=q)
+            @streaming('test', size=2, keep=True, url=self.url, max_workers=workers, queue=q, chord='default')
             def myprocess(window):
                 logger.debug("*** processing {}".format(window.data))
                 from minibatch import connectdb
@@ -218,9 +218,8 @@ class MiniBatchTests(TestCase):
         for i in range(10):
             stream.append({'index': i})
         # give it some time to process
-        logger.debug("waiting")
         # note it takes at least 25 seconds using 1 worker (5 windows, 5 seconds)
-        # so we expect to fail
+        logger.debug("waiting")
         self.sleep(12)
         q.put(True)
         if expect_fail:
@@ -236,7 +235,7 @@ class MiniBatchTests(TestCase):
         self._do_test_slow_emitfn(workers=1, expect_fail=True, timeout=30)
 
     def test_slow_emitfn_parallel_workers(self):
-        self._do_test_slow_emitfn(workers=5, expect_fail=False, timeout=12)
+        self._do_test_slow_emitfn(workers=5, expect_fail=False, timeout=15)
 
     def test_buffer_cleaned(self):
         stream = Stream.get_or_create('test', url=self.url)
@@ -258,18 +257,22 @@ class MiniBatchTests(TestCase):
         self.assertEqual(participant.role, 'producer')
         self.assertTrue(participant.active)
         participant.ACTIVE_INTERVAL = 0  # simulate inactivity
+        participant.GRACE_PERIOD = 0  # simulate no grace period
         self.assertFalse(participant.active)
         participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
+        participant.GRACE_PERIOD = 5  # simulate short grace period
         participant.beat()
         self.assertTrue(participant.active)
         participant.leave()
-        self.assertEqual(0, Participant.objects.count())
+        if Participant.objects.count() > 0:
+            print("participants", Participant.objects.all())
+        self.assertEqual(0, Participant.objects.count(), f"participant not removed, got {Participant.objects.all()}")
         # leadership
         # -- check leader is selected automatically and correctly
         participants = []
         for i in range(10):
             participants.append(Participant.register('test', 'producer', hostname=str(i)))
-        self.assertEqual(10, Participant.objects.count())
+        self.assertEqual(10, Participant.objects.count(), f'expected 10 participants, got {Participant.objects.all()}')
         max_elector = max(p.elector for p in Participant.objects().no_cache())
         leader = Participant.leader('test')
         self.assertIsInstance(leader, Participant)
@@ -279,13 +282,18 @@ class MiniBatchTests(TestCase):
         leader.leave()
         for p in list(Participant.for_stream('test'))[0:5]:
             p.leave()
-        self.assertEqual(4, Participant.objects.count())
+        self.assertEqual(4, Participant.objects.count(), f'expected 4 participants left, got {Participant.objects.all()}')
         leader2 = Participant.leader('test')
         self.assertNotEqual(leader.hostname, leader2.hostname)
         # -- remove all participants
         for p in Participant.for_stream('test'):
             p.leave()
-        self.assertEqual(0, Participant.objects.count())
+        self.assertEqual(0, Participant.objects.count(), f"participant not removed, got {Participant.objects.all()}")
+
+    def test_participants_multiple(self):
+        # attempt to catch concurrency errors
+        for i in range(10):
+            self.test_participants()
 
     def test_chords_single_consumer(self):
         Participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
@@ -303,15 +311,15 @@ class MiniBatchTests(TestCase):
         workers = 5
         procs = self._consumer_pool(workers=workers, stream='test-multi', size=2, keep=True)
         assertEventually(lambda: len(stream.as_producer.chords) == workers,
-                         lambda: f"expected 6 chords, got {len(stream.as_producer.chords)}",
-                         timeout=10)
+                         lambda: f"expected {workers} chords, got {len(stream.as_producer.chords)}",
+                         timeout=15)
         # fill stream
         for i in range(100):
             stream.append({'index': i})
             # print("all chords", stream.as_producer._all_chords)
         assertEventually(lambda: len(set(w.chord for w in stream.buffer())) == workers,
                          lambda: f"expected 5 chords, got {len(set(w.chord for w in stream.buffer()))}",
-                         timeout=10)
+                         timeout=15)
         self.assertEqual(workers, len(Participant.for_stream(stream, role='consumer')))
         stream.stop()
         self._close_pool(procs)

--- a/minibatch/tests/test_minibatch.py
+++ b/minibatch/tests/test_minibatch.py
@@ -1,7 +1,8 @@
-import logging
+from collections import Counter
 from multiprocessing import Process, Queue
 from unittest import TestCase
 
+import logging
 import multiprocessing
 import sys
 import time
@@ -14,7 +15,7 @@ from minibatch.window import CountWindow
 # use this for debugging subprocesses
 logging.basicConfig(level=logging.DEBUG)
 logger = multiprocessing.get_logger()
-# logger = multiprocessing.log_to_stderr()
+logger = multiprocessing.log_to_stderr()
 logger.setLevel('INFO')
 
 
@@ -268,6 +269,7 @@ class MiniBatchTests(TestCase):
         self.assertEqual(10, Participant.objects.count())
         max_elector = max(p.elector for p in Participant.objects().no_cache())
         leader = Participant.leader('test')
+        self.assertIsInstance(leader, Participant)
         self.assertEqual(max_elector, leader.elector)
         # modify participant lists
         # -- remove current leader and a few more
@@ -281,3 +283,51 @@ class MiniBatchTests(TestCase):
         for p in Participant.for_stream('test'):
             p.leave()
         self.assertEqual(0, Participant.objects.count())
+
+    def test_chords(self):
+        from minibatch import streaming
+        Participant.ACTIVE_INTERVAL = 1 # simulate short activity timeout
+        stream = Stream.get_or_create('test', url=self.url)
+        stream.append({'foo': 'bar'})
+        print(stream.buffer())
+        print(Participant.producers(stream))
+
+        def consumer(q):
+            logger.debug("starting consumer on={self.url}".format(**locals()))
+            url = str(self.url)
+
+            # note the stream decorator blocks the consumer and runs the decorated
+            # function asynchronously upon the window criteria is satisfied
+            @streaming('test', size=2, keep=True, url=self.url, queue=q)
+            def myprocess(window):
+                logger.debug("*** processing {}".format(window.data))
+                from minibatch import connectdb
+                try:
+                    sleepdot(5)
+                    db = connectdb(url=url)
+                    db.processed.insert_one({'data': window.data or {}})
+                except Exception as e:
+                    logger.error(e)
+                    raise
+                return window
+
+        procs = []
+        for i in range(5):
+            q = Queue()
+            proc = Process(target=consumer, args=(q,))
+            procs.append((q, proc))
+            proc.start()
+        time.sleep(10)
+        print("consumers", stream.consumers)
+        # fill stream
+        for i in range(100):
+            print("all chords", stream.as_producer._all_chords)
+            stream.append({'index': i})
+        counts = Counter([w.chord for w in stream.buffer()])
+        print(counts)
+        print(Participant.for_stream(stream))
+        time.sleep(50)
+        for q, proc in procs:
+            q.put(True)
+            proc.join()
+

--- a/minibatch/tests/test_minibatch.py
+++ b/minibatch/tests/test_minibatch.py
@@ -13,7 +13,7 @@ from minibatch.tests.util import delete_database
 from minibatch.window import CountWindow
 
 # use this for debugging subprocesses
-logLevel = logging.DEBUG
+logLevel = logging.INFO
 logging.basicConfig(level=logLevel, force=True)
 logger = multiprocessing.get_logger()
 multiprocessing.log_to_stderr()
@@ -299,9 +299,9 @@ class MiniBatchTests(TestCase):
 
     def test_chords_multiple_consumers(self):
         Participant.ACTIVE_INTERVAL = 1  # simulate short activity timeout
-        stream = Stream.get_or_create('test', url=self.url)
-        workers = 1
-        procs = self._consumer_pool(workers=workers, stream='test', size=2, keep=True)
+        stream = Stream.get_or_create('test-multi', url=self.url)
+        workers = 5
+        procs = self._consumer_pool(workers=workers, stream='test-multi', size=2, keep=True)
         assertEventually(lambda: len(stream.as_producer.chords) == workers,
                          lambda: f"expected 6 chords, got {len(stream.as_producer.chords)}",
                          timeout=10)

--- a/minibatch/tests/util.py
+++ b/minibatch/tests/util.py
@@ -11,7 +11,10 @@ def delete_database(url=None, dbname='test'):
 
 
 class LocalExecutor(Executor):
-    def submit(self, fn):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def submit(self, fn, /, *args, **kwargs):
         result = fn()
         future = Future()
         future.set_result(result)

--- a/minibatch/util.py
+++ b/minibatch/util.py
@@ -31,3 +31,19 @@ class ProcessLocal(dict):
     def __contains__(self, item):
         self._check_pid()
         return (self._cache or super()).__contains__(item)
+
+
+class resilient:
+    # make a logger that doesn't crash on exceptions
+    # due to the stream being closed on exit
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __getattr__(self, attr):
+        return resilient(getattr(self.obj, attr))
+
+    def __call__(self, *args, **kwargs):
+        try:
+            return self.obj(*args, **kwargs)
+        except Exception as e:
+            pass

--- a/minibatch/util.py
+++ b/minibatch/util.py
@@ -1,0 +1,33 @@
+import os
+
+
+class ProcessLocal(dict):
+    def __init__(self, *args, cache=None, **kwargs):
+        self._pid = os.getpid()
+        self._cache = cache
+        super().__init__(*args, **kwargs)
+
+    def _check_pid(self):
+        if self._pid != os.getpid():
+            self.clear()
+            self._pid = os.getpid()
+
+    def __getitem__(self, k):
+        self._check_pid()
+        return (self._cache or super()).__getitem__(k)
+
+    def __setitem__(self, key, value):
+        self._check_pid()
+        super().__setitem__(key, value)
+
+    def keys(self):
+        self._check_pid()
+        return (self._cache or super()).keys()
+
+    def clear(self):
+        self._cache.clear() if self._cache else None
+        return super().clear()
+
+    def __contains__(self, item):
+        self._check_pid()
+        return (self._cache or super()).__contains__(item)

--- a/minibatch/window.py
+++ b/minibatch/window.py
@@ -7,7 +7,7 @@ from queue import Empty
 
 from minibatch import Buffer, Stream, logger
 from minibatch.marshaller import SerializableFunction, MinibatchFuture
-from minibatch.models import Window
+from minibatch.models import Window, Participant
 
 
 class WindowEmitter(object):
@@ -100,6 +100,14 @@ class WindowEmitter(object):
         self.stream.modify(last_read=datetime.datetime.utcnow())
 
     @property
+    def consumer(self):
+        return Participant.myself(self.stream, 'consumer')
+
+    @property
+    def chord(self):
+        return self.consumer.chord
+
+    @property
     def stream(self):
         if self._stream:
             return self._stream
@@ -137,6 +145,7 @@ class WindowEmitter(object):
 
     def emit(self, qs, query_args=None):
         window = Window(stream=self.stream.name,
+                        chord=self.chord,
                         query=query_args,
                         data=[obj.data for obj in qs]).save()
         if self.emitfn:
@@ -173,6 +182,7 @@ class WindowEmitter(object):
         return self._stop
 
     def run(self, blocking=True):
+        self.consumer.start()
         while not self.should_stop():
             self._run_once()
             logger.debug("sleeping")
@@ -187,6 +197,7 @@ class WindowEmitter(object):
             except Exception as e:
                 logger.debug(e)
         logger.debug('stopped running')
+        self.consumer.stop()
 
     def _run_once(self):
         logger.debug("testing window ready")
@@ -258,7 +269,9 @@ class FixedTimeWindow(WindowEmitter):
 
     def query(self, *args):
         last_read, max_read = args
+        # TODO refactor base fltkwargs for all emitters
         fltkwargs = dict(stream=self.stream_name,
+                         chord=self.chord,
                          created__gte=last_read, created__lte=max_read)
         return Buffer.objects.no_cache().filter(**fltkwargs)
 
@@ -299,13 +312,17 @@ class RelaxedTimeWindow(FixedTimeWindow):
     def query(self, *args):
         last_read, max_read = args
         fltkwargs = dict(stream=self.stream_name,
-                         created__lte=max_read, processed=False)
+                         chord=self.chord,
+                         created__lte=max_read,
+                         processed=False)
         return Buffer.objects.no_cache().filter(**fltkwargs)
 
 
 class CountWindow(WindowEmitter):
     def window_ready(self):
-        fltkwargs = dict(stream=self.stream_name, processed=False)
+        fltkwargs = dict(stream=self.stream_name,
+                         chord=self.chord,
+                         processed=False)
         qs = Buffer.objects.no_cache().filter(**fltkwargs).limit(self.interval)
         n_docs = qs.count(with_limit_and_skip=True)
         self._qs = qs

--- a/minibatch/window.py
+++ b/minibatch/window.py
@@ -82,7 +82,14 @@ class WindowEmitter(object):
         self.emit_empty = emit_empty
         self.emitfn = emitfn
         self.processfn = processfn
-        self.executor = (executor or LocalExecutor(max_workers=max_workers))
+        # a ProcessPool will be created
+        # - if max_workers > 1 or max_workers -1
+        # - else a LocalExecutor will be created (the default)
+        self.executor = executor or (
+            ProcessPoolExecutor(max_workers=None if max_workers == -1 else max_workers)
+            if max_workers is not None and (max_workers > 1 or max_workers == -1)
+            else LocalExecutor()
+        )
         self._stream = stream
         self._stream_url = stream_url
         self._delete_on_commit = True
@@ -108,6 +115,7 @@ class WindowEmitter(object):
     @property
     def consumer(self):
         self._consumer = self._consumer or self.stream.as_consumer
+        self._consumer.chord = self._chord or self._consumer.chord
         return self._consumer
 
     @property
@@ -203,6 +211,8 @@ class WindowEmitter(object):
 
     def run(self, blocking=True):
         logger.debug(f'{self} start running')
+        # be sure to register as a consumer
+        self._consumer = self.consumer
         while not self.should_stop():
             self._run_once()
             self.sleep()

--- a/minibatch/window.py
+++ b/minibatch/window.py
@@ -1,4 +1,4 @@
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, ProcessPoolExecutor
 
 import datetime
 import logging
@@ -8,6 +8,7 @@ from queue import Empty
 from minibatch import Buffer, Stream, logger
 from minibatch.marshaller import SerializableFunction, MinibatchFuture
 from minibatch.models import Window
+from minibatch.tests.util import LocalExecutor
 
 
 class WindowEmitter(object):
@@ -81,7 +82,7 @@ class WindowEmitter(object):
         self.emit_empty = emit_empty
         self.emitfn = emitfn
         self.processfn = processfn
-        self.executor = (executor or ThreadPoolExecutor(max_workers=max_workers))
+        self.executor = (executor or LocalExecutor(max_workers=max_workers))
         self._stream = stream
         self._stream_url = stream_url
         self._delete_on_commit = True
@@ -349,4 +350,4 @@ class CountWindow(WindowEmitter):
 
     def sleep(self):
         import time
-        time.sleep(0.1)
+        time.sleep(1e-6)

--- a/minibatch/window.py
+++ b/minibatch/window.py
@@ -1,4 +1,4 @@
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import datetime
 import logging
@@ -7,7 +7,7 @@ from queue import Empty
 
 from minibatch import Buffer, Stream, logger
 from minibatch.marshaller import SerializableFunction, MinibatchFuture
-from minibatch.models import Window, Participant
+from minibatch.models import Window
 
 
 class WindowEmitter(object):
@@ -75,19 +75,24 @@ class WindowEmitter(object):
     def __init__(self, stream_name, interval=None, processfn=None,
                  emitfn=None, emit_empty=False, executor=None,
                  max_workers=None, stream=None, stream_url=None,
-                 forwardfn=None, queue=None):
+                 forwardfn=None, chord=None, queue=None):
         self.stream_name = stream_name
         self.interval = interval if interval is not None else 1
         self.emit_empty = emit_empty
         self.emitfn = emitfn
         self.processfn = processfn
-        self.executor = (executor or ProcessPoolExecutor(max_workers=max_workers))
+        self.executor = (executor or ThreadPoolExecutor(max_workers=max_workers))
         self._stream = stream
         self._stream_url = stream_url
         self._delete_on_commit = True
         self._forwardfn = forwardfn
         self._stop = False
         self._queue = queue
+        self._chord = chord
+        self._consumer = None
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.stream_name}, chord={self.chord})"
 
     def query(self, *args):
         raise NotImplementedError
@@ -101,11 +106,15 @@ class WindowEmitter(object):
 
     @property
     def consumer(self):
-        return Participant.myself(self.stream, 'consumer')
+        self._consumer = self._consumer or self.stream.as_consumer
+        return self._consumer
 
     @property
     def chord(self):
-        return self.consumer.chord
+        # set the chord to the consumer's chord
+        # -- we only do it once, so we don't end up creating a new consumer each time
+        self._chord = self._chord or self.consumer.chord
+        return self._chord
 
     @property
     def stream(self):
@@ -149,7 +158,7 @@ class WindowEmitter(object):
                         query=query_args,
                         data=[obj.data for obj in qs]).save()
         if self.emitfn:
-            logging.debug("calling emitfn")
+            logging.debug(f"{self} calling emitfn")
             try:
                 sjob = SerializableFunction(self.emitfn, window)
                 future = self.executor.submit(sjob)
@@ -166,60 +175,63 @@ class WindowEmitter(object):
             self._forwardfn(data)
 
     def sleep(self):
+        logger.debug(f"{self} sleeping for {self.interval} seconds")
         time.sleep((self.interval or self.stream.interval) / 2.0)
+
+    def stop(self):
+        self._stop = True
+        try:
+            if self.executor:
+                self.executor.shutdown(wait=True, cancel_futures=True)
+        except Exception as e:
+            logger.debug(e)
+        self.stream.stop()
 
     def should_stop(self):
         if self._queue is not None:
             try:
                 stop_message = self._queue.get(block=False)
-                logger.debug("queue result {}".format(self._stop))
+                logger.debug(f"{self} queue result {self._stop}")
             except Empty:
-                logger.debug("queue was empty")
+                logger.debug(f"{self} queue was empty")
             else:
                 if stop_message:
                     self._stop = True
-        logger.debug("should stop")
+        logger.debug(f"{self} should stop {self._stop}")
         return self._stop
 
     def run(self, blocking=True):
-        self.consumer.start()
+        logger.debug(f'{self} start running')
         while not self.should_stop():
             self._run_once()
-            logger.debug("sleeping")
             self.sleep()
-            logger.debug("awoke")
+            logger.debug(f"{self} awoke")
             if not blocking:
                 break
-        if blocking:
-            # if we did not block, keep executor running
-            try:
-                self.executor.shutdown(wait=True)
-            except Exception as e:
-                logger.debug(e)
-        logger.debug('stopped running')
-        self.consumer.stop()
+        self.stop()
+        logger.debug(f'{self} stopped running')
 
     def _run_once(self):
-        logger.debug("testing window ready")
+        logger.debug(f"{self} testing window ready")
         ready, query_args = self.window_ready()
         if ready:
-            logger.debug("window ready")
+            logger.debug(f"{self} window ready")
             qs = self.query(*query_args)
             qs = self.process(qs)
             self.timestamp(*query_args)
             # note self.emit is usin an async executor
             # that returns a future
             if qs or self.emit_empty:
-                logger.debug("Emitting")
+                logger.debug(f"{self} emitting")
                 future = self.emit(qs, query_args)
-                logger.debug("got future {}".format(future))
+                logger.debug(f"{self} got future {future}")
                 future['qs'] = qs
                 future['query_args'] = query_args
 
                 def emit_done(future):
                     # this is called once upon future resolves
                     future = MinibatchFuture(future)
-                    logger.debug("emit done {}".format(future))
+                    logger.debug(f"{self} emit done {future}")
                     qs = future.qs
                     window = future.window
                     try:
@@ -232,7 +244,7 @@ class WindowEmitter(object):
                             data = data.data
                         self.forward(data)
                     finally:
-                        logger.debug('emit done')
+                        logger.debug(f'{self} emit done')
                     self.sleep()
 
                 future.add_done_callback(emit_done)


### PR DESCRIPTION
Introducing explicit consumer and producer roles, enabling scalable multi-producer and multi-consumer streaming.

how it works
- producers reach a consensus on leadership so that there is always one leading producer
- consumers are assigned a unique chord id (a chord is a straight connection from one point to another, https://en.wikipedia.org/wiki/Chord_(geometry))
- all messages inserted by a producer are sent to a specific chord, or select one at random
- multiple producers can insert messages concurrently, while each message is processed by at most one consumer
- if required multiple consumers can subscribe to the same chord, thus providing a broadcasting mechanism
